### PR TITLE
Fix CPU usage error with 32bit awk and long uptimes

### DIFF
--- a/update-motd.d/15-system
+++ b/update-motd.d/15-system
@@ -56,7 +56,7 @@ uptime="$uptime $(color $dimInfoColor "* $(date -d "@"$(grep btime /proc/stat | 
 label3="$uptime"
 label3="$(color $statsLabelColor "Uptime") $(color $bulletColor "..")$(color $statsLabelColor ".") $(color $infoColor "$label3")"
 
-label4="$(awk -v a="$(awk '/cpu /{print $2+$3+$4+$5+$6+$7+$8+$9+$10,$5}' /proc/stat; sleep 0.3)" '/cpu /{split(a,b," "); printf "%.1f%%", 100*(($2+$3+$4+$5+$6+$7+$8+$9+$10-b[1])-($5-b[2]))/($2+$3+$4+$5+$6+$7+$8+$9+$10-b[1])}' /proc/stat)"
+label4="$(awk -v a="$(awk '/cpu /{print $2+$3+$4+$6+$7+$8+$9+$10,$5}' /proc/stat; sleep 0.3)" '/cpu /{split(a,b," "); printf "%.1f%%", 100*($2+$3+$4+$6+$7+$8+$9+$10-b[1])/(($2+$3+$4+$6+$7+$8+$9+$10-b[1]) + ($5-b[2]))}' /proc/stat)"
 label4="$(color $statsLabelColor "Cpu") $(color $bulletColor "....")$(color $statsLabelColor ".") $(color $infoColor $label4)"
 
 label5="$(df -h ~ | awk 'NR==2 { printf "%sB / %sB \\e[38;5;144m* Free: %sB\\e[0m",$3,$2,$4; }')"


### PR DESCRIPTION
Greetings,

I have encountered the problem, that my cpu usage in the motd would show values like 103% or -97%.
After some searching i found the issue. 

The version of awk on my rpi is
```
$ awk -W version

mawk 1.3.4 20200120
Copyright 2008-2019,2020, Thomas E. Dickey
Copyright 1991-1996,2014, Michael D. Brennan

random-funcs:       srandom/random
regex-funcs:        internal
compiled limits:
sprintf buffer      8192
maximum-integer     2147483647
```
Note the maximum-integer of 2 billion

Output of my /proc/stat is
```
$ cat /proc/stat
cpu  2270794 3385 8782791 4555485915 579486 0 92152 0 0 0
```
Note the idle time of 4 billion at position $5 (uptime is 132 days)

this causes problems when calculating the sum of all the cputimes:
```
$ echo $(awk '/cpu /{print $2+$3+$4+$5+$6+$7+$8+$9+$10,$5}' /proc/stat;)
4.56728e+09 4555553681
```
and consequently awk prints an imprecise float number instead of an integer which screws up the following calculations

Forcing it to print integers doesn't work, it then hits the max value of awk
```
$ echo $(awk '/cpu /{printf "%d %d",$2+$3+$4+$5+$6+$7+$8+$9+$10,$5}' /proc/stat;)
2147483647 2147483647
```

The solution was to change the math around a bit (result is of course the same), so that awk never "prints" an integer that is bigger than 2 billion
```
$ echo $(awk -v a="$(awk '/cpu /{print $2+$3+$4+$6+$7+$8+$9+$10,$5}' /proc/stat; sleep 0.3)" '/cpu /{split(a,b," "); printf "%.1f%%", 100*($2+$3+$4+$6+$7+$8+$9+$10-b[1])/(($2+$3+$4+$6+$7+$8+$9+$10-b[1]) + ($5-b[2]))}' /proc/stat)
0.8%
```

This will of course fail once the cpu "busy" time sum is bigger than 2 billion but considering that on my (admittedly very inactive) raspberry pi that sum is currently around 11 million (after 132 days of uptime) that should not happen very soon.